### PR TITLE
Fix some Meson deprecated functions and warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,7 @@ if get_option('windows')
     datadir = 'data'
     pkgdatadir = datadir
     iconsdir = datadir / 'icons'
-    podir = meson.source_root() / 'po'
+    podir = meson.project_source_root() / 'po'
 else
     prefix = get_option('prefix')
     bindir = prefix / get_option('bindir')
@@ -43,7 +43,7 @@ else
     datadir = prefix / get_option('datadir')
     pkgdatadir = datadir / meson.project_name()
     iconsdir = datadir / 'icons'
-    podir = meson.source_root() / 'po'
+    podir = meson.project_source_root() / 'po'
 endif
 gettext_package = meson.project_name()
 
@@ -64,8 +64,8 @@ endif
 
 meson.add_dist_script(
   'build-aux/dist-vendor.sh',
-  meson.build_root() / 'meson-dist' / meson.project_name() + '-' + version,
-  meson.source_root()
+  meson.project_build_root() / 'meson-dist' / meson.project_name() + '-' + version,
+  meson.project_source_root()
 )
 
 if get_option('profile') == 'development'

--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,7 @@ gettext_package = meson.project_name()
 
 if get_option('profile') == 'development'
   profile = 'Devel'
-  vcs_tag = run_command('git', 'rev-parse', '--short', 'HEAD').stdout().strip()
+  vcs_tag = run_command('git', 'rev-parse', '--short', 'HEAD', check: true).stdout().strip()
   if vcs_tag == ''
     version_suffix = '-devel'
   else
@@ -71,7 +71,7 @@ meson.add_dist_script(
 if get_option('profile') == 'development'
   # Setup pre-commit hook for ensuring coding style is always consistent
   message('Setting up git pre-commit hook..')
-  run_command('cp', '-f', 'hooks/pre-commit.hook', '.git/hooks/pre-commit')
+  run_command('cp', '-f', 'hooks/pre-commit.hook', '.git/hooks/pre-commit', check: true)
 endif
 
 subdir('data')


### PR DESCRIPTION
Since this project support Meson 0.59 and above the `meson.source_root` and `meson.build_root` functions can be safely replaced by their non-deprecated versions, removing a few build warnings.

https://mesonbuild.com/Release-notes-for-0-56-0.html#mesonbuild_root-and-mesonsource_root-are-deprecated

I also set the check parameter of the `run_command` function to true (failing if command status code is not OK) since the default value changed to true in recent Meson versions to unsure a consistent build behaviour between Meson versions and remove a build warning.

