### PR TITLE
flatpak: update org.gnome.platform to 46

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-20.04
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-44
+      image: bilelmoussaoui/flatpak-github-actions:gnome-46
       options: --privileged
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-20.04
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-44
+      image: bilelmoussaoui/flatpak-github-actions:gnome-46
       options: --privileged
     steps:
       - uses: actions/checkout@v2

--- a/build-aux/io.github.achetagames.epic_asset_manager.Devel.json
+++ b/build-aux/io.github.achetagames.epic_asset_manager.Devel.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.achetagames.epic_asset_manager.Devel",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "44",
+  "runtime-version": "46",
   "sdk": "org.gnome.Sdk",
   "command": "epic_asset_manager",
   "sdk-extensions": [

--- a/build-aux/io.github.achetagames.epic_asset_manager.json
+++ b/build-aux/io.github.achetagames.epic_asset_manager.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.achetagames.epic_asset_manager",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "44",
+  "runtime-version": "46",
   "sdk": "org.gnome.Sdk",
   "command": "epic_asset_manager",
   "sdk-extensions": [


### PR DESCRIPTION
```
Info: runtime org.gnome.Platform branch 44 is end-of-life, with reason:
   The GNOME 44 runtime is no longer supported as of March 20, 2024. Please ask your application developer to migrate to a supported platform.
Info: applications using this runtime:
   io.github.achetagames.epic_asset_manager
```