### PR TITLE
All around ui improvements

### DIFF
--- a/data/resources/ui/logged_in/engines/engine_detail.ui
+++ b/data/resources/ui/logged_in/engines/engine_detail.ui
@@ -2,38 +2,32 @@
 <interface>
     <template class="EpicEngineDetails" parent="GtkBox">
         <property name="orientation">vertical</property>
-        <child>
-            <object class="GtkBox">
-                <child>
-                    <object class="GtkBox">
-                        <property name="hexpand">true</property>
-                        <property name="halign">end</property>
-                        <child>
-                            <object class="GtkButton" id="launch_button">
-                                <property name="name">engine_launch_button</property>
-                                <property name="action-name">engine_details.launch</property>
-                                <child>
-                                    <object class="GtkBox">
-                                        <property name="valign">center</property>
-                                        <property name="halign">center</property>
-                                        <child>
-                                            <object class="GtkImage">
-                                                <property name="icon-name">media-playback-start-symbolic</property>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkLabel">
-                                                <property name="label" translatable="yes">Launch</property>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                    </object>
-                </child>
-            </object>
-        </child>
+            <child>
+                <object class="GtkBox">
+                    <property name="hexpand">true</property>
+                    <property name="halign">fill</property>
+                    <property name="margin-top">12</property>
+                    <property name="margin-bottom">12</property>
+                    <property name="margin-start">12</property>
+                    <property name="margin-end">12</property>
+                    <child>
+                        <object class="GtkButton" id="launch_button">
+                            <property name="name">engine_launch_button</property>
+                            <property name="action-name">engine_details.launch</property>
+                            <property name="halign">end</property>
+                            <property name="valign">center</property>
+                            <property name="css-classes">suggested-action
+pill</property>
+                            <child>
+                                <object class="AdwButtonContent">
+                                    <property name="icon-name">media-playback-start-symbolic</property>
+                                    <property name="label" translatable="yes">Launch</property>
+                                </object>
+                            </child>
+                        </object>
+                    </child>
+                </object>
+            </child>
         <child>
             <object class="GtkSeparator">
                 <property name="orientation">horizontal</property>

--- a/data/resources/ui/logged_in/engines/engines.ui
+++ b/data/resources/ui/logged_in/engines/engines.ui
@@ -4,10 +4,15 @@
     <template class="EpicEnginesBox" parent="GtkBox">
         <property name="hexpand">true</property>
         <property name="vexpand">true</property>
+        <property name="css-classes">view</property>
         <child>
             <object class="GtkScrolledWindow">
                 <property name="hexpand">true</property>
                 <property name="vexpand">true</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
                 <property name="child">
                     <object class="GtkGridView" id="engine_grid">
                         <property name="halign">fill</property>

--- a/data/resources/ui/logged_in/engines/engines_side.ui
+++ b/data/resources/ui/logged_in/engines/engines_side.ui
@@ -17,12 +17,18 @@
                         <property name="orientation">vertical</property>
                         <child>
                             <object class="GtkBox">
+                                <property name="margin-top">12</property>
+                                <property name="margin-bottom">12</property>
+                                <property name="margin-start">12</property>
+                                <property name="margin-end">12</property>
                                 <child>
                                     <object class="GtkButton">
                                         <property name="halign">start</property>
-                                        <property name="valign">start</property>
+                                        <property name="valign">center</property>
                                         <property name="action-name">engines_side.close</property>
                                         <property name="icon-name">go-next-symbolic</property>
+                                        <property name="css-classes">flat
+pill</property>
                                     </object>
                                 </child>
                                 <child>
@@ -33,8 +39,9 @@
                                                           bind-property="title"
                                                           bind-flags="sync-create"/>
                                                 <property name="ellipsize">middle</property>
-                                                <property name="halign">start</property>
+                                                <property name="halign">center</property>
                                                 <property name="use-markup">true</property>
+                                                <property name="css-classes">title-1</property>
                                             </object>
                                         </child>
                                     </object>

--- a/data/resources/ui/logged_in/library/asset.ui
+++ b/data/resources/ui/logged_in/library/asset.ui
@@ -11,6 +11,7 @@
                             <object class="GtkImage" id="image">
                                 <property name="name">thumbnail</property>
                                 <property name="icon-name">ue-logo-symbolic</property>
+                                <property name="hexpand">true</property>
                                 <property name="width-request">128</property>
                                 <property name="height-request">128</property>
                                 <property name="pixel-size">128</property>
@@ -31,6 +32,7 @@
                 </property>
                 <child type="overlay">
                     <object class="GtkImage">
+                        <property name="css-classes">warning</property>
                         <property name="icon-name">starred</property>
                         <property name="pixel-size">35</property>
                         <property name="halign">end</property>

--- a/data/resources/ui/logged_in/library/asset_detail.ui
+++ b/data/resources/ui/logged_in/library/asset_detail.ui
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
     <template class="EpicAssetDetails" parent="GtkBox">
+        <property name="halign">fill</property>
+        <property name="vexpand">true</property>
         <child>
             <object class="GtkSeparator"/>
         </child>
@@ -13,66 +15,66 @@
                     <object class="GtkBox">
                         <property name="orientation">vertical</property>
                         <child>
+                            <object class="GtkInfoBar" id="warning">
+                                <property name="css-classes">warning</property>
+                                <property name="message-type">GTK_MESSAGE_ERROR</property>
+                                <property name="revealed">false</property>
+                                <child>
+                                    <object class="GtkLabel" id="warning_message">
+                                    </object>
+                                </child>
+                            </object>
+                        </child>
+                        <child>
                             <object class="GtkBox">
+                                <property name="orientation">horizontal</property>
+                                <property name="margin-top">24</property>
+                                <property name="margin-bottom">24</property>
+                                <property name="margin-start">12</property>
+                                <property name="margin-end">12</property>
+                                <property name="spacing">6</property>
+                                <child>
+                                    <object class="GtkButton">
+                                        <property name="halign">start</property>
+                                        <property name="valign">fill</property>
+                                        <property name="action-name">details.close</property>
+                                        <property name="css-classes">flat
+pill</property>
+                                        <property name="icon-name">go-next-symbolic</property>
+                                    </object>
+                                </child>
+                                <child>
+                                    <object class="GtkLabel" id="title">
+                                        <property name="css-classes">title-1</property>
+                                        <property name="ellipsize">middle</property>
+                                        <property name="halign">center</property>
+                                        <property name="hexpand">true</property>
+                                    </object>
+                                </child>
                                 <child>
                                     <object class="GtkButton" id="favorite">
-                                        <property name="halign">start</property>
-                                        <property name="valign">start</property>
+                                        <property name="halign">end</property>
+                                        <property name="valign">center</property>
+                                        <property name="css-classes">flat
+circular</property>
                                         <property name="action-name">details.toggle_favorite</property>
                                         <property name="icon-name">non-starred-symbolic</property>
                                     </object>
                                 </child>
                                 <child>
-                                    <object class="GtkLabel" id="title">
-                                        <property name="ellipsize">middle</property>
-                                        <property name="halign">start</property>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkInfoBar" id="warning">
-                                <property name="message-type">GTK_MESSAGE_ERROR</property>
-                                <property name="revealed">false</property>
-                                <child>
-                                    <object class="GtkLabel" id="warning_message">
-
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkBox">
-                                <child>
-                                    <object class="GtkButton">
-                                        <property name="halign">start</property>
-                                        <property name="valign">start</property>
-                                        <property name="action-name">details.close</property>
-                                        <property name="icon-name">go-next-symbolic</property>
-                                    </object>
-                                </child>
-                                <child>
                                     <object class="GtkBox">
-                                        <property name="hexpand">true</property>
+                                        <property name="hexpand">false</property>
                                         <property name="halign">end</property>
+                                        <property name="css-classes">linked</property>
                                         <child>
                                             <object class="GtkButton" id="information_button">
+                                                <property name="valign">center</property>
                                                 <property name="name">asset_details_button</property>
                                                 <property name="action-name">details.show_asset_details</property>
                                                 <child>
-                                                    <object class="GtkBox">
-                                                        <property name="valign">center</property>
-                                                        <property name="halign">center</property>
-                                                        <child>
-                                                            <object class="GtkImage">
-                                                                <property name="icon-name">dialog-information-symbolic</property>
-                                                            </object>
-                                                        </child>
-                                                        <child>
-                                                            <object class="GtkLabel">
-                                                                <property name="label" translatable="yes">Details</property>
-                                                            </object>
-                                                        </child>
+                                                    <object class="AdwButtonContent">
+                                                        <property name="icon-name">dialog-information-symbolic</property>
+                                                        <property name="label" translatable="yes">Details</property>
                                                     </object>
                                                 </child>
                                             </object>
@@ -80,6 +82,7 @@
                                         <child>
                                             <object class="GtkMenuButton" id="actions_menu">
                                                 <property name="direction">down</property>
+                                                <property name="valign">center</property>
                                                 <property name="label" translatable="yes">Actions</property>
                                                 <property name="popover">
                                                     <object class="GtkPopover">
@@ -97,11 +100,6 @@
                             </object>
                         </child>
                         <child>
-                            <object class="GtkSeparator">
-                                <property name="orientation">horizontal</property>
-                            </object>
-                        </child>
-                        <child>
                             <object class="GtkRevealer" id="details_revealer">
                                 <property name="reveal-child">true</property>
                                 <child>
@@ -109,18 +107,13 @@
                                         <child>
                                             <object class="GtkBox" id="details">
                                                 <property name="orientation">vertical</property>
-                                                <child>
-                                                    <object class="AdwClamp">
-                                                        <property name="orientation">vertical</property>
-                                                        <property name="maximum-size">510</property>
-                                                        <child>
-                                                            <object class="EpicImageOverlay" id="images">
-                                                                <property name="hexpand" bind-source="EpicAssetDetails" bind-property="expanded" bind-flags="sync-create"/>
-                                                                <property name="vexpand-set">True</property>
-                                                            </object>
-                                                        </child>
-                                                    </object>
-                                                </child>
+                                                <property name="vexpand">true</property>
+                                                    <child>
+                                                        <object class="EpicImageOverlay" id="images">
+                                                            <property name="hexpand" bind-source="EpicAssetDetails" bind-property="expanded" bind-flags="sync-create"/>
+                                                            <property name="vexpand">false</property>
+                                                        </object>
+                                                    </child>
                                                 <child>
                                                     <object class="GtkSeparator">
                                                         <property name="orientation">horizontal</property>
@@ -129,7 +122,7 @@
                                                 <child>
                                                     <object class="GtkListBox" id="details_box">
                                                         <property name="selection-mode">GTK_SELECTION_NONE</property>
-                                                        <property name="vexpand">True</property>
+                                                        <property name="vexpand">true</property>
                                                     </object>
                                                 </child>
                                             </object>
@@ -141,7 +134,7 @@
                         <child>
                             <object class="GtkRevealer" id="actions_revealer">
                                 <property name="reveal-child">false</property>
-                                <property name="vexpand-set">True</property>
+                                <property name="vexpand">true</property>
                                 <property name="transition-type">slide-up</property>
                                 <child>
                                     <object class="EpicAssetActions" id="asset_actions">

--- a/data/resources/ui/logged_in/library/image_stack.ui
+++ b/data/resources/ui/logged_in/library/image_stack.ui
@@ -12,9 +12,9 @@
                                 <property name="hexpand" bind-source="EpicImageOverlay" bind-property="hexpand" bind-flags="sync-create"/>
                                 <property name="child">
                                     <object class="AdwClamp">
-                                        <property name="height-request">500</property>
                                         <property name="orientation">vertical</property>
-                                        <property name="maximum-size">500</property>
+                                        <property name="maximum-size">300</property>
+                                        <property name="height-request">400</property>
                                         <child>
                                             <object class="AdwCarousel" id="stack">
                                                 <property name="vexpand">True</property>
@@ -26,8 +26,12 @@
                                 <child type="overlay">
                                     <object class="GtkButton">
                                         <property name="halign">start</property>
-                                        <property name="opacity">0.5</property>
-                                        <property name="label">&lt;</property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-start">12</property>
+                                        <property name="css-classes">osd
+circular</property>
+                                        <property name="opacity">0.75</property>
+                                        <property name="icon-name">go-previous-symbolic</property>
                                         <property name="action-name">image_stack.prev</property>
                                         <property name="tooltip-text" translatable="yes">Previous Image</property>
                                     </object>
@@ -35,8 +39,12 @@
                                 <child type="overlay">
                                     <object class="GtkButton">
                                         <property name="halign">end</property>
-                                        <property name="opacity">0.5</property>
-                                        <property name="label">></property>
+                                        <property name="valign">center</property>
+                                        <property name="margin-end">12</property>
+                                      <property name="css-classes">osd
+circular</property>
+                                        <property name="opacity">0.75</property>
+                                        <property name="icon-name">go-next-symbolic</property>
                                         <property name="action-name">image_stack.next</property>
                                         <property name="tooltip-text" translatable="yes">Next Image</property>
                                     </object>

--- a/data/resources/ui/logged_in/library/library.ui
+++ b/data/resources/ui/logged_in/library/library.ui
@@ -1,25 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
     <template class="EpicLibraryBox" parent="GtkBox">
-        <property name="hexpand">1</property>
-        <property name="vexpand">1</property>
+        <property name="hexpand">true</property>
+        <property name="vexpand">true</property>
         <child>
             <object class="GtkBox">
                 <child>
-                    <object class="EpicSidebar" id="sidebar"></object>
+                    <object class="EpicSidebar" id="sidebar">
+                    </object>
                 </child>
                 <child>
                     <object class="GtkOverlay" id="MainOverlay">
-                        <property name="hexpand">1</property>
-                        <property name="vexpand">1</property>
+                        <property name="hexpand">true</property>
+                        <property name="vexpand">true</property>
+                        <property name="css-classes">view</property>
                         <property name="child">
                             <object class="GtkBox">
-                                <property name="hexpand">1</property>
-                                <property name="vexpand">1</property>
+                                <property name="hexpand">true</property>
+                                <property name="vexpand">true</property>
                                 <property name="orientation">vertical</property>
                                 <child>
                                     <object class="GtkScrolledWindow">
-                                        <property name="hexpand">1</property>
+                                        <property name="margin-start">8</property>
+                                        <property name="margin-end">8</property>
+                                        <property name="margin-top">48</property>
                                         <property name="vexpand">1</property>
                                         <property name="child">
                                             <object class="GtkGridView" id="asset_grid">
@@ -32,73 +36,42 @@
                             </object>
                         </property>
                         <child type="overlay">
-                            <object class="GtkBox">
+                            <object class="GtkProgressBar" id="refresh_progress">
                                 <property name="valign">end</property>
-                                <child>
-                                    <object class="GtkProgressBar" id="refresh_progress">
-                                        <property name="hexpand">true</property>
-                                        <property name="valign">center</property>
-                                        <property name="can-focus">0</property>
-                                        <property name="show-text">true</property>
-                                    </object>
-                                </child>
+                                <property name="can-focus">0</property>
+                                <property name="margin-start">6</property>
+                                <property name="margin-end">72</property>
+                                <property name="margin-top">6</property>
+                                <property name="margin-bottom">6</property>
+                                <property name="show-text">true</property>
                             </object>
                         </child>
                         <child type="overlay">
-                            <object class="GtkBox">
-                                <property name="css-classes">view</property>
-                                <property name="opacity">0.7</property>
+                            <object class="GtkLabel" id="count_label">
+                                <property name="margin-end">6</property>
+                                <property name="margin-bottom">6</property>
+                                <property name="css-classes">menu</property>
+                                <property name="label" translatable="yes">0 items</property>
                                 <property name="valign">end</property>
                                 <property name="halign">end</property>
-                                <child>
-                                    <object class="GtkLabel" id="count_label">
-                                        <property name="margin-start">5</property>
-                                        <property name="margin-end">5</property>
-                                        <property name="margin-top">5</property>
-                                        <property name="margin-bottom">5</property>
-                                        <property name="label" translatable="yes">0 items</property>
-                                    </object>
-                                </child>
                             </object>
                         </child>
-                        <child type="overlay">
+                        <child type="overlay"> <!-- SEARCH+SORT CONTROLS START -->
                             <object class="GtkBox">
-                                <property name="margin-start">5</property>
-                                <property name="margin-end">5</property>
-                                <property name="margin-top">5</property>
+                                <property name="margin-start">8</property>
+                                <property name="margin-end">8</property>
+                                <property name="margin-top">8</property>
+                                <property name="spacing">8</property>
                                 <property name="valign">start</property>
                                 <child>
-                                    <object class="GtkBox">
-                                        <property name="css-classes">background</property>
-                                        <child>
-                                            <object class="GtkToggleButton" id="search_toggle">
-                                                <property name="css-classes">background</property>
-                                                <property name="halign">start</property>
-                                                <property name="valign">start</property>
-                                                <property name="icon-name">edit-find-symbolic</property>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-                                <child>
-                                    <object class="GtkRevealer" id="search_bar">
-                                        <property name="halign">fill</property>
-                                        <property name="valign">start</property>
-                                        <property name="hexpand">true</property>
-                                        <property name="reveal-child" bind-source="search_toggle" bind-property="active" bind-flags="sync-create"/>
-                                        <property name="transition-type">slide-right</property>
-                                        <property name="margin-start">5</property>
-                                        <property name="margin-end">5</property>
-                                        <child>
-                                            <object class="GtkSearchEntry" id="asset_search">
-                                                <property name="css-classes">background</property>
-                                            </object>
-                                        </child>
+                                    <object class="GtkSearchEntry" id="asset_search">
+                                      <property name="hexpand">true</property>
                                     </object>
                                 </child>
                                 <child>
                                     <object class="GtkBox">
-                                        <property name="css-classes">background</property>
+                                        <property name="css-classes">linked</property>
+                                        <property name="halign">end</property>
                                         <child>
                                             <object class="GtkComboBoxText" id="select_order_by">
                                                 <items>
@@ -118,13 +91,15 @@
                                     </object>
                                 </child>
                             </object>
-                        </child>
+                        </child> <!-- SEARCH+SORT CONTROLS END -->
                     </object>
                 </child>
-                <child>
-                    <object class="EpicAssetDetails" id="details"/>
-                </child>
+                <property name="width-request">330</property>
             </object>
+        </child>
+        <!-- <property name="homogeneous">true</property> -->
+        <child>
+            <object class="EpicAssetDetails" id="details"/>
         </child>
     </template>
 </interface>

--- a/data/resources/ui/logged_in/library/sidebar/sidebar.ui
+++ b/data/resources/ui/logged_in/library/sidebar/sidebar.ui
@@ -45,7 +45,7 @@
                                                 </child>
                                                 <child>
                                                     <object class="GtkBox">
-                                                        <property name="vexpand">True</property>
+                                                        <property name="vexpand">true</property>
                                                         <property name="halign">end</property>
                                                         <child>
                                                             <object class="GtkSeparator">
@@ -68,53 +68,79 @@
                                 <child>
                                     <object class="GtkBox">
                                         <property name="orientation">vertical</property>
+                                        <property name="css-classes">background</property>
+                                        <child>
+                                          <object class="GtkBox">
+                                              <property name="margin-top">8</property>
+                                              <property name="margin-bottom">3</property>
+                                              <property name="margin-start">12</property>
+                                              <property name="margin-end">12</property>
+                                              <property name="spacing">12</property>
+                                              <child>
+                                                  <object class="GtkLabel">
+                                                      <property name="css-classes">heading</property>
+                                                      <property name="label">Filters</property>
+                                                      <property name="halign">start</property>
+                                                      <property name="valign">center</property>
+                                                  </object>
+                                              </child>
+                                              <child>
+                                                  <object class="GtkBox">
+                                                      <property name="halign">fill</property>
+                                                      <property name="css-classes">linked</property>
+                                                      <child>
+                                                          <object class="GtkToggleButton" id="downloaded_filter">
+                                                              <property name="icon-name">folder-download-symbolic</property>
+                                                              <property name="has-tooltip">true</property>
+                                                              <property name="tooltip-text">Only show downloaded</property>
+                                                              <property name="hexpand">true</property>
+                                                              <property name="halign">fill</property>
+                                                              <property name="valign">center</property>
+                                                          </object>
+                                                      </child>
+                                                      <child>
+                                                          <object class="GtkToggleButton" id="favorites_filter">
+                                                              <property name="icon-name">starred-symbolic</property>
+                                                              <property name="has-tooltip">true</property>
+                                                              <property name="tooltip-text">Only show starred</property>
+                                                              <property name="hexpand">true</property>
+                                                              <property name="halign">fill</property>
+                                                              <property name="valign">center</property>
+                                                          </object>
+                                                      </child>
+                                                  </object>
+                                              </child>
+                                          </object>
+                                        </child>
                                         <child>
                                             <object class="GtkStack" id="stack">
                                             </object>
                                         </child>
                                         <child>
-                                            <object class="GtkBox">
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
-                                                <property name="margin-top">12</property>
-                                                <property name="margin-bottom">12</property>
-                                                <property name="spacing">12</property>
-                                                <child>
-                                                    <object class="GtkLabel">
-                                                        <property name="halign">start</property>
-                                                        <property name="label" translatable="yes">Downloaded</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkSwitch" id="downloaded_switch">
-                                                        <property name="hexpand">True</property>
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                    </object>
-                                                </child>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkBox">
-                                                <property name="margin-start">6</property>
-                                                <property name="margin-end">6</property>
-                                                <property name="margin-top">12</property>
-                                                <property name="margin-bottom">12</property>
-                                                <property name="spacing">12</property>
-                                                <child>
-                                                    <object class="GtkLabel">
-                                                        <property name="halign">start</property>
-                                                        <property name="label" translatable="yes">Favorites</property>
-                                                    </object>
-                                                </child>
-                                                <child>
-                                                    <object class="GtkSwitch" id="favorites_switch">
-                                                        <property name="hexpand">True</property>
-                                                        <property name="halign">end</property>
-                                                        <property name="valign">center</property>
-                                                    </object>
-                                                </child>
-                                            </object>
+                                          <object class="GtkBox">
+                                              <property name="css-classes">view</property>
+                                              <child>
+                                                  <object class="GtkButton" id="marketplace_button">
+                                                      <property name="action-name">sidebar.marketplace</property>
+                                                      <property name="halign">fill</property>
+                                                      <property name="valign">center</property>
+                                                      <property name="hexpand">true</property>
+                                                      <property name="tooltip-text" translatable="yes">Open Marketplace</property>
+                                                      <property name="css-classes">pill
+flat</property>
+                                                      <property name="margin-top">8</property>
+                                                      <property name="margin-bottom">8</property>
+                                                      <property name="margin-start">10</property>
+                                                      <property name="margin-end">10</property>
+                                                      <child>
+                                                          <object class="AdwButtonContent">
+                                                              <property name="icon-name">web-browser-symbolic</property>
+                                                              <property name="label" translatable="yes">Marketplace</property>
+                                                          </object>
+                                                      </child>
+                                                  </object>
+                                              </child>
+                                          </object>
                                         </child>
                                     </object>
                                 </child>
@@ -129,39 +155,13 @@
                         <property name="orientation">vertical</property>
                         <property name="hexpand">true</property>
                         <child>
-                            <object class="GtkButton">
-                                <property name="action-name">sidebar.marketplace</property>
-                                <property name="halign">fill</property>
-                                <property name="hexpand">true</property>
-                                <property name="tooltip-text" translatable="yes">Open Marketplace</property>
-                                <property name="valign">center</property>
-                                <child>
-                                    <object class="GtkBox">
-                                        <property name="valign">center</property>
-                                        <property name="halign">fill</property>
-                                        <child>
-                                            <object class="GtkImage">
-                                                <property name="icon-name">x-office-presentation-symbolic</property>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkLabel" id="marketplace_label">
-                                                <property name="hexpand">true</property>
-                                                <property name="label" translatable="yes"/>
-                                            </object>
-                                        </child>
-                                    </object>
-                                </child>
-                            </object>
-                        </child>
-                        <child>
-                            <object class="GtkButton" id="expand_button">
+                            <object class="GtkToggleButton" id="expand_button">
                                 <property name="name">category_button</property>
                                 <property name="action-name">sidebar.expand</property>
-                                <property name="halign">fill</property>
-                                <property name="hexpand">true</property>
                                 <property name="tooltip-text" translatable="yes">Expand Sidebar</property>
                                 <property name="valign">center</property>
+                                <property name="can-shrink">true</property>
+                                <!-- <property name="icon-name">go-next-symbolic</property> -->
                                 <child>
                                     <object class="GtkBox">
                                         <property name="valign">center</property>
@@ -169,12 +169,6 @@
                                         <child>
                                             <object class="GtkImage" id="expand_image">
                                                 <property name="icon-name">go-next-symbolic</property>
-                                            </object>
-                                        </child>
-                                        <child>
-                                            <object class="GtkLabel" id="expand_label">
-                                                <property name="hexpand">true</property>
-                                                <property name="label" translatable="yes"/>
                                             </object>
                                         </child>
                                     </object>
@@ -187,7 +181,6 @@
         </child>
         <child>
             <object class="GtkSeparator">
-
             </object>
         </child>
     </template>

--- a/data/resources/ui/logged_in/projects/projects.ui
+++ b/data/resources/ui/logged_in/projects/projects.ui
@@ -4,10 +4,15 @@
     <template class="EpicProjectsBox" parent="GtkBox">
         <property name="hexpand">true</property>
         <property name="vexpand">true</property>
+        <property name="css-classes">view</property>
         <child>
             <object class="GtkScrolledWindow">
                 <property name="hexpand">true</property>
                 <property name="vexpand">true</property>
+                <property name="margin-top">12</property>
+                <property name="margin-bottom">12</property>
+                <property name="margin-start">12</property>
+                <property name="margin-end">12</property>
                 <property name="child">
                     <object class="GtkGridView" id="projects_grid">
                         <property name="halign">fill</property>

--- a/data/resources/ui/preferences/dir_row.ui
+++ b/data/resources/ui/preferences/dir_row.ui
@@ -6,11 +6,11 @@
         <property name="hexpand">true</property>
         <child>
             <object class="GtkBox">
-              <property name="spacing">8</property>
+              <property name="css-classes">linked</property>
+              <property name="margin-top">6</property>
+              <property name="margin-bottom">6</property>
                 <child>
                     <object class="GtkButton">
-                        <property name="margin-top">6</property>
-                        <property name="margin-bottom">6</property>
                         <property name="action-name">dir_row.up</property>
                         <property name="icon-name">go-up-symbolic</property>
                         <property name="valign">center</property>
@@ -18,22 +18,18 @@
                 </child>
                 <child>
                     <object class="GtkButton">
-                        <property name="margin-top">6</property>
-                        <property name="margin-bottom">6</property>
                         <property name="action-name">dir_row.down</property>
                         <property name="icon-name">go-down-symbolic</property>
                         <property name="valign">center</property>
                     </object>
                 </child>
-                <child>
-                    <object class="GtkButton">
-                        <property name="margin-top">6</property>
-                        <property name="margin-bottom">6</property>
-                        <property name="action-name">dir_row.remove</property>
-                        <property name="icon-name">list-remove</property>
-                        <property name="valign">center</property>
-                    </object>
-                </child>
+            </object>
+        </child>
+        <child>
+            <object class="GtkButton">
+                <property name="action-name">dir_row.remove</property>
+                <property name="icon-name">list-remove</property>
+                <property name="valign">center</property>
             </object>
         </child>
     </template>

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -18,8 +18,8 @@
         </section>
     </menu>
     <template class="EpicAssetManagerWindow" parent="GtkApplicationWindow">
-        <property name="default-width">800</property>
-        <property name="default-height">400</property>
+        <property name="default-width">700</property>
+        <property name="default-height">450</property>
         <property name="title" translatable="yes">Epic Asset Manager</property>
         <child type="titlebar">
             <object class="AdwHeaderBar" id="headerbar">
@@ -34,6 +34,16 @@
                         </binding>
                     </object>
                 </property>
+                <!-- <child type="start"> --> <!-- TODO: use this button instead of EpicSidebar's -->
+                <!--     <object class="GtkToggleButton" id="expand_button"> -->
+                <!--         <property name="name">category_button</property> -->
+                <!--         <property name="action-name">sidebar.expand</property> -->
+                <!--         <property name="tooltip-text" translatable="yes">Expand Sidebar</property> -->
+                <!--         <property name="halign">center</property> -->
+                <!--         <property name="valign">center</property> -->
+                <!--         <property name="icon-name">sidebar-show-symbolic</property> -->
+                <!--     </object> -->
+                <!-- </child> -->
                 <child type="start">
                     <object class="GtkButton" id="refresh">
                         <property name="halign">center</property>

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,5 +1,6 @@
 use crate::config;
 use crate::window::EpicAssetManagerWindow;
+use adw::subclass::prelude::*;
 use gio::ApplicationFlags;
 use glib::clone;
 use gtk4::prelude::*;
@@ -146,11 +147,12 @@ pub mod imp {
     }
 
     impl GtkApplicationImpl for EpicAssetManager {}
+    impl AdwApplicationImpl for EpicAssetManager {}
 }
 
 glib::wrapper! {
     pub struct EpicAssetManager(ObjectSubclass<imp::EpicAssetManager>)
-        @extends gio::Application, gtk4::Application, @implements gio::ActionMap, gio::ActionGroup;
+        @extends gio::Application, gtk4::Application, @implements gio::ActionMap, gio::ActionGroup, adw::Application;
 }
 
 impl Default for EpicAssetManager {

--- a/src/ui/widgets/logged_in/library/asset_detail.rs
+++ b/src/ui/widgets/logged_in/library/asset_detail.rs
@@ -418,6 +418,7 @@ impl EpicAssetDetails {
                         #[cfg(target_os = "linux")]
                         {
                             self_.warning.set_revealed(true);
+                            self_.warning_message.set_wrap(true);
                             self_.warning_message.set_markup("This is a Windows Build of the Engine. To install Linux version please use the <a href=\"engines\">Engines</a> tab.");
                         }
                     }

--- a/src/ui/widgets/logged_in/library/mod.rs
+++ b/src/ui/widgets/logged_in/library/mod.rs
@@ -45,8 +45,6 @@ pub mod imp {
         #[template_child]
         pub asset_search: TemplateChild<gtk4::SearchEntry>,
         #[template_child]
-        pub search_toggle: TemplateChild<gtk4::ToggleButton>,
-        #[template_child]
         pub select_order_by: TemplateChild<gtk4::ComboBoxText>,
         #[template_child]
         pub order: TemplateChild<gtk4::Button>,
@@ -89,7 +87,6 @@ pub mod imp {
                 sidebar: TemplateChild::default(),
                 asset_grid: TemplateChild::default(),
                 asset_search: TemplateChild::default(),
-                search_toggle: TemplateChild::default(),
                 select_order_by: TemplateChild::default(),
                 order: TemplateChild::default(),
                 count_label: TemplateChild::default(),
@@ -498,7 +495,6 @@ impl EpicLibraryBox {
             .asset_search
             .connect_search_changed(clone!(@weak self as library => move |_| {
                 let self_ = library.imp();
-                self_.search_toggle.set_active(true);
             }));
     }
 


### PR DESCRIPTION
I left a commented out sidebar button on the headerbar (in window.ui); do you know how to connect it to the sidebar to use it instead of the existing expand_button?

# Before:
![Screenshot from 2024-09-25 21-48-52](https://github.com/user-attachments/assets/b6fd580a-aa59-43d7-949e-0b38a41885ff)


# After:
![Screenshot from 2024-09-25 21-48-54](https://github.com/user-attachments/assets/d5835f7a-0c21-47a1-b585-a3d1c0f5c417)