### PR TITLE
Changes to styling of assets list and details pane.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ package/
 package.zip
 /.flatpak-builder/
 /_build/
+/.idea

--- a/data/resources/ui/logged_in/library/asset.ui
+++ b/data/resources/ui/logged_in/library/asset.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
     <template class="EpicAsset" parent="GtkBox">
-        <property name="width-request">128</property>
+        <property name="width-request">256</property>
         <child>
             <object class="GtkOverlay">
                 <property name="child">
@@ -14,6 +14,7 @@
                                 <property name="width-request">128</property>
                                 <property name="height-request">128</property>
                                 <property name="pixel-size">128</property>
+                                <property name="hexpand">True</property>
                                 <property name="tooltip-text" translatable="yes" bind-source="EpicAsset" bind-property="label" bind-flags="sync-create"/>
                             </object>
                         </child>

--- a/src/ui/widgets/logged_in/library/asset_detail.rs
+++ b/src/ui/widgets/logged_in/library/asset_detail.rs
@@ -518,22 +518,14 @@ impl EpicAssetDetails {
         }
 
         if let Some(title) = &asset.title {
-            // self.add_info_row("", &gtk4::Label::new(Some(title)));
-            //Make big and center text
-
-            // let label = gtk4::Label::builder()
-            //     .label(Some(title))
-            //     .wrap(true)
-            //     .xalign(0.0);
-            // label.set_markup(&html2pango::matrix_html_to_markup(desc).replace("\n\n", "\n"));
-
             let label = gtk4::Label::builder()
                 .label(title)
                 .wrap(true)
                 .use_markup(true)
-                .label(&format!("<span font_desc=\"50\"><u><b>{}</b></u></span>", title))
+                .label(&format!("<span font_desc=\"50\"><b>{}</b></span>", title))
                 .valign(gtk4::Align::Center)
                 .halign(gtk4::Align::Center)
+                .hexpand(true)
                 .build();
             self.add_info_row("", &label);
         }

--- a/src/ui/widgets/logged_in/library/asset_detail.rs
+++ b/src/ui/widgets/logged_in/library/asset_detail.rs
@@ -6,6 +6,7 @@ use gtk4::glib::clone;
 use gtk4::subclass::prelude::*;
 use gtk4::{self, gio, prelude::*};
 use gtk4::{glib, CompositeTemplate};
+use gtk4::Align::Center;
 use gtk_macros::{action, get_action};
 use log::{error, info};
 
@@ -498,7 +499,7 @@ impl EpicAssetDetails {
         if let Some(title) = &asset.title {
             self_
                 .title
-                .set_markup(&format!("<b><u><big>{title}</big></u></b>"));
+                .set_markup(&format!("<b><big>{title}</big></b>"));
         }
 
         self_.images.clear();
@@ -516,8 +517,29 @@ impl EpicAssetDetails {
             self_.details_box.remove(&el);
         }
 
+        if let Some(title) = &asset.title {
+            // self.add_info_row("", &gtk4::Label::new(Some(title)));
+            //Make big and center text
+
+            // let label = gtk4::Label::builder()
+            //     .label(Some(title))
+            //     .wrap(true)
+            //     .xalign(0.0);
+            // label.set_markup(&html2pango::matrix_html_to_markup(desc).replace("\n\n", "\n"));
+
+            let label = gtk4::Label::builder()
+                .label(title)
+                .wrap(true)
+                .use_markup(true)
+                .label(&format!("<span font_desc=\"50\"><u><b>{}</b></u></span>", title))
+                .valign(gtk4::Align::Center)
+                .halign(gtk4::Align::Center)
+                .build();
+            self.add_info_row("", &label);
+        }
+
         if let Some(dev_name) = &asset.developer {
-            self.add_info_row("Developer", &gtk4::Label::new(Some(dev_name)));
+            self.add_info_row("Developer:", &gtk4::Label::new(Some(dev_name)));
         }
 
         if let Some(categories) = &asset.categories {
@@ -536,20 +558,20 @@ impl EpicAssetDetails {
                     cats.push(category.path.clone());
                 }
             }
-            self.add_info_row("Categories", &gtk4::Label::new(Some(&cats.join(", "))));
+            self.add_info_row("Categories:", &gtk4::Label::new(Some(&cats.join(", "))));
         }
 
         if let Some(platforms) = &asset.platforms() {
-            self.add_info_row("Platforms", &gtk4::Label::new(Some(&platforms.join(", "))));
+            self.add_info_row("Platforms:", &gtk4::Label::new(Some(&platforms.join(", "))));
         }
 
         if let Some(updated) = &asset.last_modified_date {
-            self.add_info_row("Updated", &gtk4::Label::new(Some(&updated.to_rfc3339())));
+            self.add_info_row("Updated:", &gtk4::Label::new(Some(&updated.to_rfc3339())));
         }
 
         if let Some(compatible_apps) = &asset.compatible_apps() {
             self.add_info_row(
-                "Compatible with",
+                "Compatible with:",
                 &gtk4::Label::new(Some(&compatible_apps.join(", ").replace("UE_", ""))),
             );
         }

--- a/src/ui/widgets/logged_in/library/asset_detail.rs
+++ b/src/ui/widgets/logged_in/library/asset_detail.rs
@@ -496,11 +496,11 @@ impl EpicAssetDetails {
         get_action!(self_.actions, @show_download_details).set_enabled(true);
         get_action!(self_.actions, @show_asset_details).set_enabled(false);
         info!("Showing details for {:?}", asset.title);
-        if let Some(title) = &asset.title {
-            self_
-                .title
-                .set_markup(&format!("<b><big>{title}</big></b>"));
-        }
+        // if let Some(title) = &asset.title {
+        //     self_
+        //         .title
+        //         .set_markup(&format!("<b><big>{title}</big></b>"));
+        // }
 
         self_.images.clear();
 

--- a/src/ui/widgets/logged_in/library/asset_detail.rs
+++ b/src/ui/widgets/logged_in/library/asset_detail.rs
@@ -518,11 +518,17 @@ impl EpicAssetDetails {
         }
 
         if let Some(title) = &asset.title {
+            //TODO: Set dynamic font size based on character length, 50 is ideal, any chracters plus 10, should be 30
+            let mut font_size = 40;
+
+            if (title.len() > 30) {
+                font_size = 30;
+            }
             let label = gtk4::Label::builder()
                 .label(title)
                 .wrap(true)
                 .use_markup(true)
-                .label(&format!("<span font_desc=\"50\"><b>{}</b></span>", title))
+                .label(&format!("<span font_desc=\"{font_size}\"><b>{}</b></span>", title))
                 .valign(gtk4::Align::Center)
                 .halign(gtk4::Align::Center)
                 .hexpand(true)


### PR DESCRIPTION
Just a few changes that hopefully you think look a little cleaner. 

Spaced out the assets a little, giving them breathing room.

Before:
![Epic Asset Manager - Assets_Before](https://github.com/user-attachments/assets/2c9a3786-7127-4a6f-9b6e-6dc8965cfc35)

After:
![Epic Asset Manager - Assets_After](https://github.com/user-attachments/assets/0b1aaf2a-975c-4894-a751-68c223c50e50)




Moved title / name of asset with the details of the asset below image.

Before:
![Epic Asset Manager - Details_Before](https://github.com/user-attachments/assets/5fdca9e8-f132-494c-9c03-27d3821e5526)


After:
![Epic Asset Manager - Details_After](https://github.com/user-attachments/assets/f85ca73b-af45-4cc9-8e7a-48da813e7b38)

