### PR TITLE
bump gnome sdk to 48 and other chores

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-46
+      image: bilelmoussaoui/flatpak-github-actions:gnome-48
       options: --privileged
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-48
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
       options: --privileged
     steps:
       - uses: actions/checkout@v4
-      - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: epic_asset_manager.flatpak
           manifest-path: build-aux/io.github.achetagames.epic_asset_manager.json

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -48,7 +48,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload analysis results to GitHub
-        uses: github/codeql-action/upload-sarif@v1
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: rust-clippy-results.sarif
           wait-for-processing: true

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -30,7 +30,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install prerequisites
-        run: sudo apt-get update && sudo apt-get install -y libgtk-4-dev libadwaita-1-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y desktop-file-utils gettext libgtk-4-dev libadwaita-1-dev meson
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -42,6 +44,11 @@ jobs:
 
       - name: Install required cargo
         run: cargo install clippy-sarif sarif-fmt
+
+      - name: Build to generate files
+        run: |
+          meson setup _build --wipe --prefix=/usr
+          ninja -C _build
 
       - name: Run rust-clippy
         run:

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install prerequisites
+        run: sudo apt-get update && sudo apt-get install -y libgtk-4-dev libadwaita-1-dev
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-46
+      image: bilelmoussaoui/flatpak-github-actions:gnome-48
       options: --privileged
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,11 +15,11 @@ jobs:
     name: "Flatpak"
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-48
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
       options: --privileged
     steps:
-      - uses: actions/checkout@v2
-      - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v6
+      - uses: actions/checkout@v4
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: epic_asset_manager.flatpak
           manifest-path: build-aux/io.github.achetagames.epic_asset_manager.Devel.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,6 @@ flatpak install  org.freedesktop.Sdk.Extension.rust-stable
 
 Alternatively you can use meson
 
-1. meson _build --prefix=/usr
+1. meson setup _build --prefix=/usr
 2. ninja -C _build
 3. ninja -C _build install

--- a/build-aux/io.github.achetagames.epic_asset_manager.Devel.json
+++ b/build-aux/io.github.achetagames.epic_asset_manager.Devel.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.achetagames.epic_asset_manager.Devel",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "command": "epic_asset_manager",
   "sdk-extensions": [

--- a/build-aux/io.github.achetagames.epic_asset_manager.json
+++ b/build-aux/io.github.achetagames.epic_asset_manager.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.achetagames.epic_asset_manager",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
+  "runtime-version": "48",
   "sdk": "org.gnome.Sdk",
   "command": "epic_asset_manager",
   "sdk-extensions": [

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@ dependency('glib-2.0', version: '>= 2.76')
 dependency('gio-2.0', version: '>= 2.76')
 dependency('gtk4', version: '>= 4.0')
 dependency(
-  'libadwaita-1', version: '>= 1.6',
+  'libadwaita-1', version: '>= 1.5',
   fallback: ['libadwaita', 'libadwaita_dep'],
   default_options: ['tests=false', 'examples=false', 'vapi=false']
 )

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('epic_asset_manager',
         'rust',
         version: '3.8.6',
         license: 'MIT',
-  meson_version: '>= 0.49')
+  meson_version: '>= 0.59')
 
 i18n = import('i18n')
 gnome = import('gnome')


### PR DESCRIPTION
- Fix rust-clippy workflow
- Update other GitHub actions where applicable
  - `actions-rs/toolchain@v1` did not get updated, as it is archived since 2023
- meson
  - adjust build instructions to not use deprecated syntax
  - bump minimum required version to 0.59 as the build config makes use of newer features
  - allow building with older versions of adwaita to allow building on more hosts
    - e.g.: `ubuntu-latest` used in GitHub Actions only has `1.5.0` available by default
    - the flatpak builder, which actually builds the flatpak ships newer versions of it, so this really is purely to unblock building
- Bump Gnome SDK to 48
  - Though 7c52f047c5cc23b1ba4fc91a30f448f6a451259b also bumped the Gnome SDK version to 47 already, but not in action workflows
```
Info: runtime org.gnome.Platform branch 46 is end-of-life, with reason:
   The GNOME 46 runtime is no longer supported as of April 17, 2025. Please ask your application developer to migrate to a supported platform.
Info: applications using this runtime:
   io.github.achetagames.epic_asset_manager
```