### PR TITLE
fix: unset WAYLAND_DISPLAY when launching UE via flatpak-spawn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "epic_asset_manager"
-version = "3.9.2"
+version = "3.9.3"
 authors = ["Milan Stastny <milan@stastnej.ch>"]
 edition = "2021"
 license-file = "LICENSE"

--- a/data/io.github.achetagames.epic_asset_manager.metainfo.xml.in.in
+++ b/data/io.github.achetagames.epic_asset_manager.metainfo.xml.in.in
@@ -65,6 +65,18 @@
     <url type="vcs-browser">https://github.com/AchetaGames/Epic-Asset-Manager</url>
     <content_rating type="oars-1.0"/>
     <releases>
+    <release version="3.9.3" date="2026-03-01">
+        <description>
+            <p>Release 3.9.3</p>
+            <ul>
+                    <li>fix: unset WAYLAND_DISPLAY when launching UE via flatpak-spawn</li>
+                    <li>docs: add AGENTS.md knowledge base files</li>
+                    <li>refactor: extract category filter expression parser into tools::category_filter</li>
+                    <li>refactor: extract auth token helpers into tools::auth</li>
+            </ul>
+        </description>
+    </release>
+
     <release version="3.9.2" date="2026-02-25">
         <description>
             <p>Fix Flathub linter issues</p>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('epic_asset_manager',
         'rust',
-        version: '3.9.2',
+        version: '3.9.3',
         license: 'MIT',
   meson_version: '>= 0.59')
 

--- a/src/ui/widgets/logged_in/engines/engine_detail.rs
+++ b/src/ui/widgets/logged_in/engines/engine_detail.rs
@@ -181,7 +181,7 @@ impl EpicEngineDetails {
                 context.setenv("GLIBC_TUNABLES", "glibc.rtld.dynamic_sort=2");
                 let app = gtk4::gio::AppInfo::create_from_commandline(
                     if crate::tools::is_sandboxed() {
-                        format!("flatpak-spawn --env='GLIBC_TUNABLES=glibc.rtld.dynamic_sort=2' --host \"{}\"", p.to_str().unwrap())
+                        format!("flatpak-spawn --env='GLIBC_TUNABLES=glibc.rtld.dynamic_sort=2' --unset-env=WAYLAND_DISPLAY --host \"{}\"", p.to_str().unwrap())
                     } else {
                         format!("\"{}\"", p.to_str().unwrap())
                     },

--- a/src/ui/widgets/logged_in/projects/project_detail.rs
+++ b/src/ui/widgets/logged_in/projects/project_detail.rs
@@ -216,7 +216,7 @@ impl UnrealProjectDetails {
                 let app = gio::AppInfo::create_from_commandline(
                     if crate::tools::is_sandboxed() {
                         format!(
-                            "flatpak-spawn --env='GLIBC_TUNABLES=glibc.rtld.dynamic_sort=2' --host \"{}\" \"{}\"",
+                            "flatpak-spawn --env='GLIBC_TUNABLES=glibc.rtld.dynamic_sort=2' --unset-env=WAYLAND_DISPLAY --host \"{}\" \"{}\"",
                             p.to_str().unwrap(),
                             path
                         )


### PR DESCRIPTION
## Summary

- Unset `WAYLAND_DISPLAY` when launching Unreal Editor via `flatpak-spawn --host` to prevent UE's Slate UI from attempting native Wayland rendering, which causes menus and tooltips to spawn at screen center
- UE falls back to X11 via XWayland, matching the behavior when launched directly

Fixes #330

## Context

Same root cause and fix approach as [AssetManagerStudio#102](https://github.com/master-technology/AssetManagerStudio/issues/102) — the Flatpak sandbox forwards `WAYLAND_DISPLAY` to the host-spawned UE process.

## Changes

- `engine_detail.rs` — Added `--unset-env=WAYLAND_DISPLAY` to `flatpak-spawn` (standalone engine launch)
- `project_detail.rs` — Added `--unset-env=WAYLAND_DISPLAY` to `flatpak-spawn` (project launch)

Also includes version bump to v3.9.3.