### PR TITLE
Color scheme overrides (for disabled dark mode enforcing + system-wide light theme default)

### DIFF
--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -438,3 +438,65 @@ button.image-button:hover {
   margin: 4px;
   border-radius: 0;
 }
+
+/* ===========================================
+   LIGHT PALETTE OVERRIDES
+   Applied when main window has `eam-light`
+   =========================================== */
+
+window.eam-light,
+window.eam-light .view,
+window.eam-light .background {
+  background-color: #f6f6f6;
+}
+
+window.eam-light headerbar,
+window.eam-light .titlebar {
+  background-color: #f6f6f6;
+  border-bottom: 1px solid #d4d4d4;
+}
+
+window.eam-light headerbar button:hover,
+window.eam-light .titlebar button:hover,
+window.eam-light windowcontrols button:hover,
+window.eam-light .navigation-sidebar button:hover,
+window.eam-light .sidebar button:hover,
+window.eam-light stacksidebar button:hover,
+window.eam-light button.close:hover,
+window.eam-light button.circular:hover,
+window.eam-light row button:hover,
+window.eam-light listbox button:hover,
+window.eam-light list button:hover,
+window.eam-light button.flat:hover,
+window.eam-light button.image-button:hover {
+  background-color: rgba(0, 0, 0, 0.08);
+}
+
+window.eam-light headerbar button:active,
+window.eam-light .titlebar button:active {
+  background-color: rgba(0, 0, 0, 0.12);
+}
+
+window.eam-light gridview > child {
+  border: 1px solid #d4d4d4;
+}
+
+window.eam-light gridview > child:hover {
+  background-color: rgba(0, 0, 0, 0.03);
+  border-color: #c4c4c4;
+}
+
+window.eam-light gridview > child:selected {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+window.eam-light .content-image,
+window.eam-light gridview picture,
+window.eam-light gridview image {
+  border: 1px solid #d4d4d4;
+}
+
+window.eam-light expander.section,
+window.eam-light .section {
+  border-bottom: 1px solid #d4d4d4;
+}

--- a/src/application.rs
+++ b/src/application.rs
@@ -240,6 +240,7 @@ impl EpicAssetManager {
         } else {
             style_manager.set_color_scheme(adw::ColorScheme::ForceDark);
         }
+        self.main_window().refresh_palette_css_class();
         let self_ = self.imp();
         let state = action.state().unwrap();
         let action_state: bool = state.get().unwrap();

--- a/src/ui/widgets/preferences/mod.rs
+++ b/src/ui/widgets/preferences/mod.rs
@@ -229,7 +229,10 @@ impl PreferencesWindow {
             .build();
         self_
             .settings
-            .connect_changed(Some("dark-mode"), |settings, _key| {
+            .connect_changed(Some("dark-mode"), clone!(
+                #[weak(rename_to=preferences)]
+                self,
+                move |settings, _key| {
                 let style_manager = adw::StyleManager::default();
                 if settings.boolean("dark-mode") {
                     style_manager.set_color_scheme(adw::ColorScheme::ForceDark);
@@ -238,7 +241,10 @@ impl PreferencesWindow {
                 } else {
                     style_manager.set_color_scheme(adw::ColorScheme::Default);
                 };
-            });
+                if let Some(window) = preferences.imp().window.get() {
+                    window.refresh_palette_css_class();
+                }
+            }));
         self_
             .settings
             .bind("cache-directory", &*self_.cache_directory_row, "subtitle")

--- a/src/window.rs
+++ b/src/window.rs
@@ -231,12 +231,24 @@ impl EpicAssetManagerWindow {
 
     pub fn refresh_palette_css_class(&self) {
         let style_manager = adw::StyleManager::default();
-        if style_manager.is_dark() {
-            self.remove_css_class("eam-light");
-            self.add_css_class("eam-dark");
-        } else {
-            self.remove_css_class("eam-dark");
-            self.add_css_class("eam-light");
+        let is_dark = style_manager.is_dark();
+        let toplevels = gtk4::Window::list_toplevels();
+
+        for i in 0..toplevels.n_items() {
+            let Some(obj) = toplevels.item(i) else {
+                continue;
+            };
+            let Ok(window) = obj.downcast::<gtk4::Window>() else {
+                continue;
+            };
+
+            if is_dark {
+                window.remove_css_class("eam-light");
+                window.add_css_class("eam-dark");
+            } else {
+                window.remove_css_class("eam-dark");
+                window.add_css_class("eam-light");
+            }
         }
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -226,6 +226,18 @@ impl EpicAssetManagerWindow {
                 style_manager.set_color_scheme(adw::ColorScheme::ForceLight);
             }
         }
+        self.refresh_palette_css_class();
+    }
+
+    pub fn refresh_palette_css_class(&self) {
+        let style_manager = adw::StyleManager::default();
+        if style_manager.is_dark() {
+            self.remove_css_class("eam-light");
+            self.add_css_class("eam-dark");
+        } else {
+            self.remove_css_class("eam-dark");
+            self.add_css_class("eam-light");
+        }
     }
 
     pub fn setup_receiver(&self) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -234,11 +234,8 @@ impl EpicAssetManagerWindow {
         let is_dark = style_manager.is_dark();
         let toplevels = gtk4::Window::list_toplevels();
 
-        for i in 0..toplevels.n_items() {
-            let Some(obj) = toplevels.item(i) else {
-                continue;
-            };
-            let Ok(window) = obj.downcast::<gtk4::Window>() else {
+        for widget in toplevels {
+            let Ok(window) = widget.downcast::<gtk4::Window>() else {
                 continue;
             };
 


### PR DESCRIPTION
# Problem

Original issue from here https://github.com/AchetaGames/Epic-Asset-Manager/issues/335

What happens:

When Dark Mode enforcing is disabled - app use default system-wide color scheme
```rust
if style_manager.system_supports_color_schemes() {
    button.set_visible(false);
    if settings.boolean("dark-mode") {
        style_manager.set_color_scheme(adw::ColorScheme::ForceDark);
    } else {
        style_manager.set_color_scheme(adw::ColorScheme::Default);
    }
}
```
and on top of that applies styles from style.css:
```
window,
.view,
.background {
  background-color: #121212;
}
```
which, in case of light system-wide default - leads to stuff life "dark window (comes from style override), dark text (from system)".

# Solution

It adds window-level code which checks if we use dark-theme or light-theme and adds specific classes (`eam-light` / `eam-dark`) and overrides colors in case of having `.eam-light`

# Result

See this 4 attached screenshots, checking all possible combinations:

- Dark-mode is not forced; system-wide default is light mode
    <img width="1855" height="682" alt="Not-forcing Dark Mode - Default Light Mode" src="https://github.com/user-attachments/assets/a784a7de-38c1-4377-883b-eb1a4d70362b" />

- Dark-mode is not forced; system-wide default is dark mode
    <img width="1855" height="682" alt="Not-forcing Dark Mode - Default Dark Mode" src="https://github.com/user-attachments/assets/2eb25116-b0f1-4c9b-bf6c-495333806ec0" />

- Forcing dark mode; system-wide default is light mode
    <img width="1855" height="682" alt="Forcing Dark Mode - Default Light Mode" src="https://github.com/user-attachments/assets/3972e65b-13b2-4d76-a4c5-18fe85bf0b64" />

- Forcing dark mode; system-wide default is dark mode
    <img width="1855" height="682" alt="Forcing Dark Mode - Default Dark Mode" src="https://github.com/user-attachments/assets/72afe7ce-b86f-42f0-8973-895bde5238ac" />
